### PR TITLE
chore: init iOS project with XcodeGen and CI

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -1,0 +1,39 @@
+name: iOS CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-14
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select latest stable Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Show Xcode version
+        run: xcodebuild -version
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Generate Xcode project
+        run: xcodegen generate
+
+      - name: Build (no code signing)
+        run: |
+          xcodebuild \
+            -project SubEdit.xcodeproj \
+            -scheme SubEdit \
+            -configuration Release \
+            -sdk iphoneos \
+            CODE_SIGNING_ALLOWED=NO \
+            build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Xcode / Swift
+DerivedData/
+build/
+*.xcworkspace
+*.xcuserstate
+*.xcuserdata/
+# SwiftPM
+.build/
+.swiftpm/
+# macOS
+.DS_Store
+# Fastlane (user-specific)
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots
+fastlane/test_output

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# subedit-ios
-App editing
+# SubEdit (iOS)
+MVP editor video con sottotitoli offline (SwiftUI + AVFoundation).
+Build: GitHub Actions (macOS), progetto generato con XcodeGen.

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleName</key><string>SubEdit</string>
+  <key>UILaunchStoryboardName</key><string></string>
+
+  <key>NSMicrophoneUsageDescription</key>
+  <string>Serve per trascrivere l'audio dei video.</string>
+  <key>NSSpeechRecognitionUsageDescription</key>
+  <string>Serve per generare sottotitoli automatici offline.</string>
+</dict>
+</plist>

--- a/Sources/App/SubEditApp.swift
+++ b/Sources/App/SubEditApp.swift
@@ -1,0 +1,8 @@
+import SwiftUI
+
+@main
+struct SubEditApp: App {
+    var body: some Scene {
+        WindowGroup { ContentView() }
+    }
+}

--- a/Sources/Components/VideoPicker.swift
+++ b/Sources/Components/VideoPicker.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+import PhotosUI
+
+struct VideoPicker: UIViewControllerRepresentable {
+    @Binding var urls: [URL]
+
+    func makeUIViewController(context: Context) -> PHPickerViewController {
+        var config = PHPickerConfiguration()
+        config.filter = .videos
+        config.selectionLimit = 0
+        let vc = PHPickerViewController(configuration: config)
+        vc.delegate = context.coordinator
+        return vc
+    }
+    func updateUIViewController(_ uiViewController: PHPickerViewController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    final class Coordinator: NSObject, PHPickerViewControllerDelegate {
+        let parent: VideoPicker
+        init(_ parent: VideoPicker) { self.parent = parent }
+        func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+            parent.urls.removeAll()
+            let group = DispatchGroup()
+            for r in results {
+                group.enter()
+                r.itemProvider.loadFileRepresentation(forTypeIdentifier: "public.movie") { url, _ in
+                    if let url = url {
+                        let dst = FileManager.default.temporaryDirectory
+                          .appendingPathComponent(UUID().uuidString + ".mov")
+                        try? FileManager.default.copyItem(at: url, to: dst)
+                        DispatchQueue.main.async { self.parent.urls.append(dst) }
+                    }
+                    group.leave()
+                }
+            }
+            group.notify(queue: .main) { picker.dismiss(animated: true) }
+        }
+    }
+}

--- a/Sources/Views/ContentView.swift
+++ b/Sources/Views/ContentView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct ContentView: View {
+    @State private var showPicker = false
+    @State private var selectedURLs: [URL] = []
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 16) {
+                Button("Seleziona clip video") { showPicker = true }
+                if !selectedURLs.isEmpty {
+                    Text("Clip selezionate: \(selectedURLs.count)")
+                }
+                Spacer()
+            }
+            .padding()
+            .navigationTitle("SubEdit")
+            .sheet(isPresented: $showPicker) {
+                VideoPicker(urls: $selectedURLs)
+            }
+        }
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -1,0 +1,19 @@
+name: SubEdit
+options:
+  deploymentTarget:
+    iOS: "15.0"
+settings:
+  base:
+    PRODUCT_BUNDLE_IDENTIFIER: it.openai.SubEdit
+    SWIFT_VERSION: 5.9
+targets:
+  SubEdit:
+    type: application
+    platform: iOS
+    sources:
+      - Sources
+      - Resources
+    settings:
+      base:
+        INFOPLIST_FILE: Resources/Info.plist
+        ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon


### PR DESCRIPTION
## Summary
- add XcodeGen project definition and SwiftUI source skeleton
- include minimal Info.plist, assets container, and README description
- configure GitHub Actions workflow to generate and build the project in CI

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e4523ca8348331ad0752a9f26e4deb